### PR TITLE
Add database selection support to DatabaseBackend

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,24 @@ TASKS = {
 
 The `id_function` must return a UUID (either `uuid.UUID` or string representation). Additionally, the PostgreSQL-specific [`RandomUUID`](https://docs.djangoproject.com/en/stable/ref/contrib/postgres/functions/#django.contrib.postgres.functions.RandomUUID) or other database expressions are supported on Django 6.0+.
 
+### Specifying a database
+
+By default, tasks are stored in the `default` database. To use a different database, set the `database` option:
+
+```python
+TASKS = {
+    "default": {
+        "BACKEND": "django_tasks.backends.database.DatabaseBackend",
+        "OPTIONS": {
+            "database": "task_queue"
+        }
+    }
+}
+```
+
+This is useful for separating task queue tables from your main application data, or using different databases for different backends.
+
+
 ## Contributing
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for information on how to contribute.

--- a/django_tasks_db/backend.py
+++ b/django_tasks_db/backend.py
@@ -18,6 +18,8 @@ from django_tasks.utils import normalize_json
 from typing_extensions import ParamSpec
 
 if TYPE_CHECKING:
+    from django.db.models.query import QuerySet
+
     from .models import DBTaskResult
 
 T = TypeVar("T")
@@ -40,6 +42,8 @@ class DatabaseBackend(BaseTaskBackend):
 
         super().__init__(alias, params)
 
+        self.database = self.options.get("database", "default")
+
         if id_function := self.options.get("id_function"):
             if callable(id_function):
                 self.id_function = id_function
@@ -48,6 +52,12 @@ class DatabaseBackend(BaseTaskBackend):
         else:
             # Fall back to the default defined on the model
             self.id_function = DBTaskResult._meta.pk.default
+
+    @property
+    def _base_queryset(self) -> "QuerySet[DBTaskResult]":
+        from .models import DBTaskResult
+
+        return DBTaskResult.objects.using(self.database)
 
     def _get_id(self) -> Any:
         result_id = self.id_function()
@@ -65,9 +75,7 @@ class DatabaseBackend(BaseTaskBackend):
         args: P.args,  # type:ignore[valid-type]
         kwargs: P.kwargs,  # type:ignore[valid-type]
     ) -> "DBTaskResult":
-        from .models import DBTaskResult
-
-        return DBTaskResult.objects.create(
+        return self._base_queryset.create(
             id=self._get_id(),
             args_kwargs=normalize_json({"args": args, "kwargs": kwargs}),
             priority=task.priority,
@@ -83,9 +91,7 @@ class DatabaseBackend(BaseTaskBackend):
         args: P.args,  # type:ignore[valid-type]
         kwargs: P.kwargs,  # type:ignore[valid-type]
     ) -> "DBTaskResult":
-        from .models import DBTaskResult
-
-        return await DBTaskResult.objects.acreate(
+        return await self._base_queryset.acreate(
             id=self._get_id(),
             args_kwargs=normalize_json({"args": args, "kwargs": kwargs}),
             priority=task.priority,
@@ -137,7 +143,7 @@ class DatabaseBackend(BaseTaskBackend):
         from .models import DBTaskResult
 
         try:
-            return DBTaskResult.objects.get(id=result_id).task_result
+            return self._base_queryset.get(id=result_id).task_result
         except (DBTaskResult.DoesNotExist, ValidationError) as e:
             raise TaskResultDoesNotExist(result_id) from e
 
@@ -145,7 +151,8 @@ class DatabaseBackend(BaseTaskBackend):
         from .models import DBTaskResult
 
         try:
-            return (await DBTaskResult.objects.aget(id=result_id)).task_result
+            db_result = await self._base_queryset.aget(id=result_id)
+            return db_result.task_result
         except (DBTaskResult.DoesNotExist, ValidationError) as e:
             raise TaskResultDoesNotExist(result_id) from e
 

--- a/django_tasks_db/management/commands/db_worker.py
+++ b/django_tasks_db/management/commands/db_worker.py
@@ -38,6 +38,7 @@ class Worker:
         startup_delay: bool,
         max_tasks: int | None,
         worker_id: str,
+        database: str = "default",
     ):
         self.queue_names = queue_names
         self.process_all_queues = "*" in queue_names
@@ -52,6 +53,7 @@ class Worker:
         self._run_tasks = 0
 
         self.worker_id = worker_id
+        self.database = database
 
     def shutdown(self, signum: int, frame: FrameType | None) -> None:
         if not self.running:
@@ -96,13 +98,17 @@ class Worker:
             time.sleep(random.random())  # noqa: S311
 
         while self.running:
-            tasks = DBTaskResult.objects.ready().filter(backend_name=self.backend_name)
+            tasks = (
+                DBTaskResult.objects.using(self.database)
+                .ready()
+                .filter(backend_name=self.backend_name)
+            )
             if not self.process_all_queues:
                 tasks = tasks.filter(queue_name__in=self.queue_names)
 
             # During this transaction, all "ready" tasks are locked. Therefore, it's important
             # it be as efficient as possible.
-            with exclusive_transaction(tasks.db):
+            with exclusive_transaction(self.database):
                 try:
                     task_result = tasks.get_locked()
                 except OperationalError as e:
@@ -326,6 +332,8 @@ class Command(BaseCommand):
             )
             reload = False
 
+        backend = task_backends[backend_name]
+
         worker = Worker(
             queue_names=queue_name.split(","),
             interval=interval,
@@ -334,6 +342,7 @@ class Command(BaseCommand):
             startup_delay=startup_delay,
             max_tasks=max_tasks,
             worker_id=worker_id,
+            database=getattr(backend, "database", "default"),
         )
 
         if reload:

--- a/django_tasks_db/management/commands/prune_db_task_results.py
+++ b/django_tasks_db/management/commands/prune_db_task_results.py
@@ -108,7 +108,11 @@ class Command(BaseCommand):
             else None
         )
 
-        results = DBTaskResult.objects.finished().filter(backend_name=backend.alias)
+        results = (
+            DBTaskResult.objects.using(backend.database)
+            .finished()
+            .filter(backend_name=backend.alias)
+        )
 
         queue_names = queue_name.split(",")
         if "*" not in queue_names:

--- a/tests/db_worker_test_settings.py
+++ b/tests/db_worker_test_settings.py
@@ -2,8 +2,11 @@ from .settings import *
 
 TASKS = {"default": {"BACKEND": "django_tasks_db.DatabaseBackend"}}
 
-# Force the test DB to be used
-if "sqlite" in DATABASES["default"]["ENGINE"]:
-    DATABASES["default"]["NAME"] = DATABASES["default"]["TEST"]["NAME"]
-else:
-    DATABASES["default"]["NAME"] = "test_" + DATABASES["default"]["NAME"]
+# Force the test DB to be used for all databases
+for db in DATABASES.values():
+    db = cast(dict[str, Any], db)
+    if "sqlite" in db.get("ENGINE", ""):
+        if "TEST" in db and "NAME" in db["TEST"]:
+            db["NAME"] = db["TEST"]["NAME"]
+    elif "NAME" in db:
+        db["NAME"] = f"test_{db['NAME']}"

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from typing import Any, cast
 
 import dj_database_url
 
@@ -32,11 +33,19 @@ DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 DATABASES = {
     "default": dj_database_url.config(
         default="sqlite:///" + os.path.join(BASE_DIR, "db.sqlite3")
-    )
+    ),
+    "secondary": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": os.path.join(BASE_DIR, "db_secondary.sqlite3"),
+    },
 }
 
-if "sqlite" in DATABASES["default"]["ENGINE"]:
-    DATABASES["default"]["TEST"] = {"NAME": os.path.join(BASE_DIR, "db-test.sqlite3")}
+for db in DATABASES.values():
+    db = cast(dict[str, Any], db)
+    if "sqlite" in db["ENGINE"]:
+        db["TEST"] = {
+            "NAME": os.path.join(BASE_DIR, f"db-test-{os.path.basename(db['NAME'])}")
+        }
 
 
 USE_TZ = True

--- a/tests/settings_fast.py
+++ b/tests/settings_fast.py
@@ -1,5 +1,5 @@
 from .settings import *
 
 # Unset custom test settings to use in-memory DB
-if "sqlite" in DATABASES["default"]["ENGINE"]:
-    del DATABASES["default"]["TEST"]
+if "sqlite" in DATABASES["default"]["ENGINE"]:  # type: ignore[operator]
+    del DATABASES["default"]["TEST"]  # type: ignore[attr-defined]

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -510,6 +510,7 @@ class DatabaseBackendTestCase(TransactionTestCase):
         "default": {
             "BACKEND": "django_tasks_db.DatabaseBackend",
             "QUEUES": ["default", "queue-1"],
+            "OPTIONS": {"database": "default"},
         },
         "dummy": {"BACKEND": "django_tasks.backends.dummy.DummyBackend"},
     }
@@ -1467,7 +1468,7 @@ class DatabaseBackendPruneTaskResultsTestCase(TransactionTestCase):
 )
 @skipIfInMemoryDB()
 class DatabaseWorkerProcessTestCase(TransactionTestCase):
-    WORKER_STARTUP_TIME = 1
+    WORKER_STARTUP_TIME = 2
 
     def setUp(self) -> None:
         self.processes: list[subprocess.Popen] = []
@@ -1550,7 +1551,7 @@ class DatabaseWorkerProcessTestCase(TransactionTestCase):
             signal.SIGTERM,
         ]:
             with self.subTest(sig):
-                result = test_tasks.sleep_for.enqueue(2)
+                result = test_tasks.sleep_for.enqueue(3)
                 self.assertEqual(DBTaskResult.objects.get(id=result.id).worker_ids, [])
 
                 self.assertGreater(result.args[0], self.WORKER_STARTUP_TIME)
@@ -1568,7 +1569,7 @@ class DatabaseWorkerProcessTestCase(TransactionTestCase):
 
                 process.send_signal(sig)
 
-                process.wait(timeout=2)
+                process.wait(timeout=3)
 
                 self.assertEqual(process.returncode, 0)
 
@@ -1728,3 +1729,97 @@ class AdminTestCase(TestCase):
         result = self.admin.display_run_after(db_task_result)
 
         self.assertEqual(result, expected_run_after)
+
+
+@override_settings(
+    TASKS={
+        "default": {
+            "BACKEND": "django_tasks_db.DatabaseBackend",
+            "OPTIONS": {"database": "default"},
+        },
+        "secondary": {
+            "BACKEND": "django_tasks_db.DatabaseBackend",
+            "OPTIONS": {"database": "secondary"},
+        },
+    }
+)
+class DatabaseSelectionTestCase(TransactionTestCase):
+    databases = {"default", "secondary"}
+
+    def tearDown(self) -> None:
+        logger = logging.getLogger("django_tasks_db")
+        tasks_logger = logging.getLogger("django_tasks")
+
+        # Reset the logger after every run, to ensure the correct `stdout` is used
+        for handler in logger.handlers:
+            logger.removeHandler(handler)
+
+        for handler in tasks_logger.handlers:
+            tasks_logger.removeHandler(handler)
+
+    def test_enqueue_to_different_databases(self) -> None:
+        result_default = test_tasks.calculate_meaning_of_life.enqueue()
+
+        result_secondary = test_tasks.calculate_meaning_of_life.using(
+            backend="secondary"
+        ).enqueue()
+
+        self.assertTrue(
+            DBTaskResult.objects.using("default").filter(id=result_default.id).exists()
+        )
+        self.assertFalse(
+            DBTaskResult.objects.using("secondary")
+            .filter(id=result_default.id)
+            .exists()
+        )
+
+        self.assertTrue(
+            DBTaskResult.objects.using("secondary")
+            .filter(id=result_secondary.id)
+            .exists()
+        )
+        self.assertFalse(
+            DBTaskResult.objects.using("default")
+            .filter(id=result_secondary.id)
+            .exists()
+        )
+
+    def test_get_result_from_correct_database(self) -> None:
+        backend = task_backends["secondary"]
+        default_backend = task_backends["default"]
+
+        db_result = DBTaskResult.objects.using("secondary").create(
+            task_path="tests.tasks.calculate_meaning_of_life",
+            args_kwargs={"args": [], "kwargs": {}},
+            run_after=test_tasks.calculate_meaning_of_life.run_after,
+            backend_name="secondary",
+        )
+
+        retrieved_result = backend.get_result(db_result.id)
+        self.assertEqual(retrieved_result.id, str(db_result.id))
+
+        with self.assertRaises(DBTaskResult.DoesNotExist):
+            DBTaskResult.objects.using("default").get(id=db_result.id)
+
+        with self.assertRaises(TaskResultDoesNotExist):
+            default_backend.get_result(db_result.id)
+
+    def test_worker_uses_correct_database(self) -> None:
+        result = test_tasks.calculate_meaning_of_life.using(
+            backend="secondary"
+        ).enqueue()
+
+        self.assertEqual(DBTaskResult.objects.ready().using("secondary").count(), 1)
+        self.assertEqual(DBTaskResult.objects.ready().using("default").count(), 0)
+
+        call_command(
+            "db_worker",
+            verbosity=0,
+            batch=True,
+            interval=0,
+            startup_delay=False,
+            backend_name="secondary",
+        )
+
+        result.refresh()
+        self.assertEqual(result.status, TaskResultStatus.SUCCESSFUL)


### PR DESCRIPTION
Adds [database](cci:1://file:///home/pravin/OpenSource/django-tasks/tests/tests/test_database_backend.py:316:4-321:96) option to DatabaseBackend to specify which database to use for tasks.
```python
TASKS = {
    "default": {
        "BACKEND": "django_tasks.backends.database.DatabaseBackend",
        "OPTIONS": {"database": "task_queue"}
    }
}
```
refs #6 
