### PR TITLE
Fix: Prevent OperationalError from dropped connections during worker sleep

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Set up a venv:
 ```sh
 python -m venv .venv
 source .venv/bin/activate
-python -m pip install -e --group dev
+python -m pip install -e . --group dev
 ```
 
 > [!TIP]

--- a/django_tasks_db/management/commands/db_worker.py
+++ b/django_tasks_db/management/commands/db_worker.py
@@ -96,6 +96,9 @@ class Worker:
             time.sleep(random.random())  # noqa: S311
 
         while self.running:
+            # Check for dropped/expired connections right after waking up
+            close_old_connections()
+
             tasks = DBTaskResult.objects.ready().filter(backend_name=self.backend_name)
             if not self.process_all_queues:
                 tasks = tasks.filter(queue_name__in=self.queue_names)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -549,7 +549,7 @@ class DatabaseBackendWorkerTestCase(TransactionTestCase):
 
                 self.assertEqual(result.status, TaskResultStatus.READY)
 
-                with self.assertNumQueries(9 if connection.vendor == "mysql" else 8):
+                with self.assertNumQueries(10 if connection.vendor == "mysql" else 8):
                     self.run_worker()
 
                 self.assertEqual(result.status, TaskResultStatus.READY)
@@ -572,7 +572,7 @@ class DatabaseBackendWorkerTestCase(TransactionTestCase):
 
         self.assertEqual(DBTaskResult.objects.ready().count(), 4)
 
-        with self.assertNumQueries(27 if connection.vendor == "mysql" else 23):
+        with self.assertNumQueries(28 if connection.vendor == "mysql" else 23):
             self.run_worker()
 
         self.assertEqual(DBTaskResult.objects.ready().count(), 0)
@@ -580,7 +580,7 @@ class DatabaseBackendWorkerTestCase(TransactionTestCase):
         self.assertEqual(DBTaskResult.objects.failed().count(), 1)
 
     def test_no_tasks(self) -> None:
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(4 if connection.vendor == "mysql" else 3):
             self.run_worker()
 
     def test_doesnt_process_different_queue(self) -> None:
@@ -588,12 +588,12 @@ class DatabaseBackendWorkerTestCase(TransactionTestCase):
 
         self.assertEqual(DBTaskResult.objects.ready().count(), 1)
 
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(4 if connection.vendor == "mysql" else 3):
             self.run_worker()
 
         self.assertEqual(DBTaskResult.objects.ready().count(), 1)
 
-        with self.assertNumQueries(9 if connection.vendor == "mysql" else 8):
+        with self.assertNumQueries(10 if connection.vendor == "mysql" else 8):
             self.run_worker(queue_name=result.task.queue_name)
 
         self.assertEqual(DBTaskResult.objects.ready().count(), 0)
@@ -603,12 +603,12 @@ class DatabaseBackendWorkerTestCase(TransactionTestCase):
 
         self.assertEqual(DBTaskResult.objects.ready().count(), 1)
 
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(4 if connection.vendor == "mysql" else 3):
             self.run_worker()
 
         self.assertEqual(DBTaskResult.objects.ready().count(), 1)
 
-        with self.assertNumQueries(9 if connection.vendor == "mysql" else 8):
+        with self.assertNumQueries(10 if connection.vendor == "mysql" else 8):
             self.run_worker(queue_name="*")
 
         self.assertEqual(DBTaskResult.objects.ready().count(), 0)
@@ -617,7 +617,7 @@ class DatabaseBackendWorkerTestCase(TransactionTestCase):
         result = test_tasks.failing_task_value_error.enqueue()
         self.assertEqual(DBTaskResult.objects.ready().count(), 1)
 
-        with self.assertNumQueries(9 if connection.vendor == "mysql" else 8):
+        with self.assertNumQueries(10 if connection.vendor == "mysql" else 8):
             self.run_worker()
 
         self.assertEqual(result.status, TaskResultStatus.READY)
@@ -646,7 +646,7 @@ class DatabaseBackendWorkerTestCase(TransactionTestCase):
         result = test_tasks.complex_exception.enqueue()
         self.assertEqual(DBTaskResult.objects.ready().count(), 1)
 
-        with self.assertNumQueries(9 if connection.vendor == "mysql" else 8):
+        with self.assertNumQueries(10 if connection.vendor == "mysql" else 8):
             self.run_worker()
 
         self.assertEqual(result.status, TaskResultStatus.READY)
@@ -691,12 +691,12 @@ class DatabaseBackendWorkerTestCase(TransactionTestCase):
 
         self.assertEqual(DBTaskResult.objects.ready().count(), 1)
 
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(4 if connection.vendor == "mysql" else 3):
             self.run_worker(backend_name="dummy")
 
         self.assertEqual(DBTaskResult.objects.ready().count(), 1)
 
-        with self.assertNumQueries(9 if connection.vendor == "mysql" else 8):
+        with self.assertNumQueries(10 if connection.vendor == "mysql" else 8):
             self.run_worker(backend_name=result.backend)
 
         self.assertEqual(DBTaskResult.objects.ready().count(), 0)
@@ -784,7 +784,7 @@ class DatabaseBackendWorkerTestCase(TransactionTestCase):
         self.assertEqual(DBTaskResult.objects.count(), 1)
         self.assertEqual(DBTaskResult.objects.ready().count(), 0)
 
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(4 if connection.vendor == "mysql" else 3):
             self.run_worker()
 
         self.assertEqual(DBTaskResult.objects.count(), 1)
@@ -795,7 +795,7 @@ class DatabaseBackendWorkerTestCase(TransactionTestCase):
 
         self.assertEqual(DBTaskResult.objects.ready().count(), 1)
 
-        with self.assertNumQueries(9 if connection.vendor == "mysql" else 8):
+        with self.assertNumQueries(10 if connection.vendor == "mysql" else 8):
             self.run_worker()
 
         self.assertEqual(DBTaskResult.objects.ready().count(), 0)


### PR DESCRIPTION
## The Problem
When running the django_tasks_db worker on cloud platforms with aggressive TCP idle timeouts (like Railway, AWS, or Heroku), the worker occasionally crashes with a psycopg.OperationalError: the connection is closed.

Currently, close_old_connections() is called at the bottom of the while self.running: loop. If the worker finds no tasks, it sleeps. During this sleep period, cloud load balancers can silently drop the network connection. When the worker wakes up and loops back to the top, it immediately attempts tasks.get_locked() using the dead connection, causing a fatal crash before it can reach the connection cleanup at the bottom of the loop.

## The Solution
This PR duplicates the close_old_connections() call at the very top of the worker loop.

- **Top check:** Validates the connection immediately upon waking up, catching network blips or database restarts that occurred during time.sleep().
- **Bottom check:** Remains in place to emulate standard Django request behavior, cleaning up expired connections or aborted transactions generated during task execution before going to sleep.

Because close_old_connections() is highly optimized and practically a no-op for healthy connections, adding it to the top of the loop introduces no measurable performance penalty while significantly increasing the worker's resilience to network realities.