### PR TITLE
fix: defer DBTaskResult import to avoid AppRegistryNotReady

### DIFF
--- a/django_tasks_db/backend.py
+++ b/django_tasks_db/backend.py
@@ -36,8 +36,6 @@ class DatabaseBackend(BaseTaskBackend):
     supports_priority = True
 
     def __init__(self, alias: str, params: dict) -> None:
-        from .models import DBTaskResult
-
         super().__init__(alias, params)
 
         if id_function := self.options.get("id_function"):
@@ -46,10 +44,18 @@ class DatabaseBackend(BaseTaskBackend):
             else:
                 self.id_function = import_string(id_function)
         else:
+            self.id_function = None
+
+    def _get_id(self) -> Any:
+        if self.id_function is None:
+            # Defer model import to avoid AppRegistryNotReady when the
+            # backend is instantiated before apps are fully loaded (e.g.
+            # by @task() decorators in third-party packages).
+            from .models import DBTaskResult
+
             # Fall back to the default defined on the model
             self.id_function = DBTaskResult._meta.pk.default
 
-    def _get_id(self) -> Any:
         result_id = self.id_function()
 
         if VERSION < (6, 0) and isinstance(result_id, Expression):


### PR DESCRIPTION
## Summary

Fixes #30

## Problem

When `@task()` decorators execute at module load time in third-party packages (e.g. wagtail), `DatabaseBackend.__init__` eagerly imports `DBTaskResult` to resolve the default id_function. This happens before Django's app registry is ready, causing `AppRegistryNotReady`.

## Fix

Defer the `DBTaskResult` import from `__init__()` to `_get_id()`, which is only called when a task is actually enqueued — by which time apps are fully loaded.

```diff
-    def __init__(self, alias, params):
-        from .models import DBTaskResult  # eager import — crashes before apps ready
         ...
-        self.id_function = DBTaskResult._meta.pk.default
+    def __init__(self, alias, params):
         ...
+        self.id_function = None  # defer resolution
+
+    def _get_id(self):
+        if self.id_function is None:
+            from .models import DBTaskResult  # lazy import — apps ready now
+            self.id_function = DBTaskResult._meta.pk.default
```

## Test Plan

- [x] Existing tests pass (no behavioral change for normal usage)
- [ ] Verify with wagtail project reproducer from issue