### PR TITLE
fix(prune): handle failed_min_age_days=0 correctly and add regression test

### DIFF
--- a/django_tasks_db/management/commands/prune_db_task_results.py
+++ b/django_tasks_db/management/commands/prune_db_task_results.py
@@ -104,7 +104,7 @@ class Command(BaseCommand):
         min_age = timezone.now() - timedelta(days=min_age_days)
         failed_min_age = (
             (timezone.now() - timedelta(days=failed_min_age_days))
-            if failed_min_age_days
+            if failed_min_age_days is not None
             else None
         )
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1411,6 +1411,31 @@ class DatabaseBackendPruneTaskResultsTestCase(TransactionTestCase):
         with self.assertRaises(TaskResultDoesNotExist):
             failed_result.refresh()
 
+    def test_failed_min_age_zero(self) -> None:
+        successful_result = test_tasks.noop_task.enqueue()
+        DBTaskResult.objects.ready().update(
+            status=TaskResultStatus.SUCCESSFUL,
+            finished_at=timezone.now() - timedelta(days=1),
+        )
+
+        failed_result = test_tasks.noop_task.enqueue()
+        DBTaskResult.objects.ready().update(
+            status=TaskResultStatus.FAILED,
+            finished_at=timezone.now() - timedelta(days=1),
+        )
+
+        self.assertEqual(DBTaskResult.objects.finished().count(), 2)
+
+        with self.assertNumQueries(3):
+            self.prune_task_results(min_age_days=14, failed_min_age_days=0)
+
+        self.assertEqual(DBTaskResult.objects.finished().count(), 1)
+
+        successful_result.refresh()
+
+        with self.assertRaises(TaskResultDoesNotExist):
+            failed_result.refresh()
+
     def test_dry_run(self) -> None:
         test_tasks.noop_task.enqueue()
 


### PR DESCRIPTION
Treat failed_min_age_days=0 as an explicit value (not as None) in prune_db_task_results. Add a regression test for the zero-day failed retention case to prevent future regressions.