### PR TITLE
Clarify validation for worker task limits and intervals

### DIFF
--- a/django_tasks_db/management/commands/db_worker.py
+++ b/django_tasks_db/management/commands/db_worker.py
@@ -209,13 +209,13 @@ def valid_interval(val: str) -> float:
     if not math.isfinite(num):
         raise ArgumentTypeError("Must be a finite floating point value")
     if num < 0:
-        raise ArgumentTypeError("Must be greater than zero")
+        raise ArgumentTypeError("Must be zero or greater")
     return num
 
 
 def valid_max_tasks(val: str) -> int:
     num = int(val)
-    if num < 0:
+    if num <= 0:
         raise ArgumentTypeError("Must be greater than zero")
     return num
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -728,7 +728,7 @@ class DatabaseBackendWorkerTestCase(TransactionTestCase):
                 execute_from_command_line(
                     ["django-admin", "db_worker", "--interval", "-1"]
                 )
-        self.assertIn("Must be greater than zero", output.getvalue())
+        self.assertIn("Must be zero or greater", output.getvalue())
 
     def test_infinite_interval(self) -> None:
         output = StringIO()
@@ -749,12 +749,29 @@ class DatabaseBackendWorkerTestCase(TransactionTestCase):
 
         self.assertEqual(worker_class.mock_calls[0].kwargs["interval"], 0.1)
 
+    def test_zero_interval(self) -> None:
+        with mock.patch(
+            "django_tasks_db.management.commands.db_worker.Worker"
+        ) as worker_class:
+            execute_from_command_line(["django-admin", "db_worker", "--interval", "0"])
+
+        self.assertEqual(worker_class.mock_calls[0].kwargs["interval"], 0)
+
     def test_negative_max_tasks(self) -> None:
         output = StringIO()
         with redirect_stderr(output):
             with self.assertRaises(SystemExit):
                 execute_from_command_line(
                     ["django-admin", "db_worker", "--max-tasks", "-1"]
+                )
+        self.assertIn("Must be greater than zero", output.getvalue())
+
+    def test_zero_max_tasks(self) -> None:
+        output = StringIO()
+        with redirect_stderr(output):
+            with self.assertRaises(SystemExit):
+                execute_from_command_line(
+                    ["django-admin", "db_worker", "--max-tasks", "0"]
                 )
         self.assertIn("Must be greater than zero", output.getvalue())
 


### PR DESCRIPTION
I noticed the validation for `--max-tasks` and `--interval` both rejected negative values, but zero should probably mean different things for each option.

For `--max-tasks`, I think the value should be strictly greater than zero. A limit of zero does not really make sense as a task execution limit, and because the worker checks the limit after running a task, `--max-tasks 0` can still allow one task to run before exiting.

For `--interval`, zero seems valid. It means the worker should not sleep between checks when no tasks are available, which is different from an invalid negative interval.

