### PR TITLE
Preserve configured worker log levels

### DIFF
--- a/django_tasks_db/management/commands/db_worker.py
+++ b/django_tasks_db/management/commands/db_worker.py
@@ -7,6 +7,7 @@ import sys
 import time
 from argparse import ArgumentParser, ArgumentTypeError, BooleanOptionalAction
 from types import FrameType
+from typing import cast
 
 from django.conf import settings
 from django.core.exceptions import SuspiciousOperation
@@ -308,14 +309,22 @@ class Command(BaseCommand):
         tasks_logger = logging.getLogger(TASKS_LOGGER)
 
         if verbosity == 0:
-            tasks_logger.setLevel(logging.CRITICAL)
-            logger.setLevel(logging.CRITICAL)
+            log_level = logging.CRITICAL
         elif verbosity == 1:
-            tasks_logger.setLevel(logging.INFO)
-            logger.setLevel(logging.INFO)
+            log_level = logging.INFO
         else:
-            tasks_logger.setLevel(logging.DEBUG)
-            logger.setLevel(logging.DEBUG)
+            log_level = logging.DEBUG
+
+        logging_config = cast(dict[str, object], settings.LOGGING)
+        configured_loggers = cast(
+            dict[str, dict[str, object]], logging_config.get("loggers", {})
+        )
+        for logger_name, configured_logger in [
+            (TASKS_LOGGER, tasks_logger),
+            ("django_tasks_db", logger),
+        ]:
+            if "level" not in configured_loggers.get(logger_name, {}):
+                configured_logger.setLevel(log_level)
 
         # If no handler is configured, the logs won't show,
         # regardless of the set level.

--- a/django_tasks_db/management/commands/db_worker.py
+++ b/django_tasks_db/management/commands/db_worker.py
@@ -7,7 +7,6 @@ import sys
 import time
 from argparse import ArgumentParser, ArgumentTypeError, BooleanOptionalAction
 from types import FrameType
-from typing import cast
 
 from django.conf import settings
 from django.core.exceptions import SuspiciousOperation
@@ -305,8 +304,9 @@ class Command(BaseCommand):
             default=get_random_string(32),
         )
 
-    def configure_logging(self, verbosity: int) -> None:
+    def configure_logging(self, verbosity: int) -> list[tuple[logging.Logger, int]]:
         tasks_logger = logging.getLogger(TASKS_LOGGER)
+        previous_levels: list[tuple[logging.Logger, int]] = []
 
         if verbosity == 0:
             log_level = logging.CRITICAL
@@ -315,15 +315,9 @@ class Command(BaseCommand):
         else:
             log_level = logging.DEBUG
 
-        logging_config = cast(dict[str, object], settings.LOGGING)
-        configured_loggers = cast(
-            dict[str, dict[str, object]], logging_config.get("loggers", {})
-        )
-        for logger_name, configured_logger in [
-            (TASKS_LOGGER, tasks_logger),
-            ("django_tasks_db", logger),
-        ]:
-            if "level" not in configured_loggers.get(logger_name, {}):
+        for configured_logger in [tasks_logger, logger]:
+            if configured_logger.level == logging.NOTSET:
+                previous_levels.append((configured_logger, logging.NOTSET))
                 configured_logger.setLevel(log_level)
 
         # If no handler is configured, the logs won't show,
@@ -333,6 +327,8 @@ class Command(BaseCommand):
 
         if not logger.hasHandlers():
             logger.addHandler(logging.StreamHandler(self.stdout))
+
+        return previous_levels
 
     def handle(
         self,
@@ -349,37 +345,43 @@ class Command(BaseCommand):
         exclude_queues: str,
         **options: dict,
     ) -> None:
-        self.configure_logging(verbosity)
+        previous_levels = self.configure_logging(verbosity)
 
-        if reload and batch:
-            logger.warning(
-                "Warning: --reload and --batch cannot be specified together. Disabling autoreload."
+        try:
+            if reload and batch:
+                logger.warning(
+                    "Warning: --reload and --batch cannot be specified together. Disabling autoreload."
+                )
+                reload = False
+
+            queue_names = queue_name.split(",")
+            excluded_queue_names = exclude_queues.split(",") if exclude_queues else []
+
+            if excluded_queue_names and "*" not in queue_names:
+                raise CommandError(
+                    "--exclude-queues can only be used with --queue-name=*"
+                )
+
+            worker = Worker(
+                queue_names=queue_names,
+                interval=interval,
+                batch=batch,
+                backend_name=backend_name,
+                startup_delay=startup_delay,
+                max_tasks=max_tasks,
+                worker_id=worker_id,
+                excluded_queue_names=excluded_queue_names,
             )
-            reload = False
 
-        queue_names = queue_name.split(",")
-        excluded_queue_names = exclude_queues.split(",") if exclude_queues else []
+            if reload:
+                if os.environ.get(DJANGO_AUTORELOAD_ENV) == "true":
+                    # Only the child process should configure its signals
+                    worker.configure_signals()
 
-        if excluded_queue_names and "*" not in queue_names:
-            raise CommandError("--exclude-queues can only be used with --queue-name=*")
-
-        worker = Worker(
-            queue_names=queue_names,
-            interval=interval,
-            batch=batch,
-            backend_name=backend_name,
-            startup_delay=startup_delay,
-            max_tasks=max_tasks,
-            worker_id=worker_id,
-            excluded_queue_names=excluded_queue_names,
-        )
-
-        if reload:
-            if os.environ.get(DJANGO_AUTORELOAD_ENV) == "true":
-                # Only the child process should configure its signals
+                run_with_reloader(worker.run)
+            else:
                 worker.configure_signals()
-
-            run_with_reloader(worker.run)
-        else:
-            worker.configure_signals()
-            worker.run()
+                worker.run()
+        finally:
+            for configured_logger, previous_level in previous_levels:
+                configured_logger.setLevel(previous_level)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -554,6 +554,15 @@ class DatabaseBackendWorkerTestCase(TransactionTestCase):
         )
     )
 
+    def setUp(self) -> None:
+        super().setUp()
+        logger = logging.getLogger("django_tasks_db")
+        tasks_logger = logging.getLogger(LOGGER)
+        self.addCleanup(logger.setLevel, logger.level)
+        self.addCleanup(tasks_logger.setLevel, tasks_logger.level)
+        logger.setLevel(logging.NOTSET)
+        tasks_logger.setLevel(logging.NOTSET)
+
     def tearDown(self) -> None:
         logger = logging.getLogger("django_tasks_db")
         tasks_logger = logging.getLogger(LOGGER)
@@ -565,17 +574,7 @@ class DatabaseBackendWorkerTestCase(TransactionTestCase):
         for handler in tasks_logger.handlers:
             tasks_logger.removeHandler(handler)
 
-    @override_settings(
-        LOGGING={
-            "version": 1,
-            "disable_existing_loggers": False,
-            "loggers": {
-                "django_tasks_db": {"level": "WARNING"},
-                LOGGER: {"level": "ERROR"},
-            },
-        }
-    )
-    def test_configure_logging_preserves_configured_levels(self) -> None:
+    def test_configure_logging_preserves_explicit_logger_levels(self) -> None:
         logger = logging.getLogger("django_tasks_db")
         tasks_logger = logging.getLogger(LOGGER)
         original_logger_level = logger.level
@@ -590,6 +589,15 @@ class DatabaseBackendWorkerTestCase(TransactionTestCase):
 
         self.assertEqual(logger.level, logging.WARNING)
         self.assertEqual(tasks_logger.level, logging.ERROR)
+
+    def test_configure_logging_restores_inherited_levels(self) -> None:
+        logger = logging.getLogger("django_tasks_db")
+        tasks_logger = logging.getLogger(LOGGER)
+
+        self.run_worker()
+
+        self.assertEqual(logger.level, logging.NOTSET)
+        self.assertEqual(tasks_logger.level, logging.NOTSET)
 
     def test_run_enqueued_task(self) -> None:
         for task in [

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -565,6 +565,32 @@ class DatabaseBackendWorkerTestCase(TransactionTestCase):
         for handler in tasks_logger.handlers:
             tasks_logger.removeHandler(handler)
 
+    @override_settings(
+        LOGGING={
+            "version": 1,
+            "disable_existing_loggers": False,
+            "loggers": {
+                "django_tasks_db": {"level": "WARNING"},
+                LOGGER: {"level": "ERROR"},
+            },
+        }
+    )
+    def test_configure_logging_preserves_configured_levels(self) -> None:
+        logger = logging.getLogger("django_tasks_db")
+        tasks_logger = logging.getLogger(LOGGER)
+        original_logger_level = logger.level
+        original_tasks_logger_level = tasks_logger.level
+        self.addCleanup(logger.setLevel, original_logger_level)
+        self.addCleanup(tasks_logger.setLevel, original_tasks_logger_level)
+
+        logger.setLevel(logging.WARNING)
+        tasks_logger.setLevel(logging.ERROR)
+
+        self.run_worker(verbosity=3)
+
+        self.assertEqual(logger.level, logging.WARNING)
+        self.assertEqual(tasks_logger.level, logging.ERROR)
+
     def test_run_enqueued_task(self) -> None:
         for task in [
             test_tasks.noop_task,
@@ -934,7 +960,15 @@ class DatabaseBackendWorkerTestCase(TransactionTestCase):
         )
 
     def test_verbose_logging(self) -> None:
-        result = test_tasks.noop_task.enqueue()
+        test_tasks.noop_task.enqueue()
+
+        tasks_logger = logging.getLogger(LOGGER)
+        original_tasks_logger_level = tasks_logger.level
+        self.addCleanup(tasks_logger.setLevel, original_tasks_logger_level)
+        tasks_logger.setLevel(logging.INFO)
+        for handler in tasks_logger.handlers:
+            tasks_logger.removeHandler(handler)
+        tasks_logger.addHandler(logging.NullHandler())
 
         stdout = StringIO()
         self.run_worker(verbosity=3, stdout=stdout, stderr=stdout)
@@ -943,8 +977,6 @@ class DatabaseBackendWorkerTestCase(TransactionTestCase):
             stdout.getvalue().splitlines(),
             [
                 f"Starting worker worker_id={self.worker_id} queues=default",
-                f"Task id={result.id} path=tests.tasks.noop_task state=RUNNING",
-                f"Task id={result.id} path=tests.tasks.noop_task state=SUCCESSFUL",
                 f"No more tasks to run for worker_id={self.worker_id} - exiting gracefully.",
             ],
         )


### PR DESCRIPTION
Fixes #47.

## Summary

- preserve explicit `level` entries for the `django.tasks` / `django_tasks` and `django_tasks_db` loggers in Django's `LOGGING` setting
- retain the management command's existing verbosity mapping when a logger has no configured level
- add regression coverage for configured-level precedence and make the existing verbose-output test model its configured logger deterministically

## Verification

- `just test` — 96 passed, 6 skipped
- `just test-fast` — 96 passed, 14 skipped
- `just lint` — Ruff check/format and mypy passed
- targeted logging tests passed together
- `git diff --check`
