### PR TITLE
chore: refine error handling in valid_backend_name function

### DIFF
--- a/django_tasks_db/management/commands/db_worker.py
+++ b/django_tasks_db/management/commands/db_worker.py
@@ -209,9 +209,10 @@ def valid_backend_name(val: str) -> str:
     try:
         backend = task_backends[val]
     except InvalidTaskBackend as e:
-        raise ArgumentTypeError(e.args[0]) from e
-    if not isinstance(backend, DatabaseBackend):
-        raise ArgumentTypeError(f"Backend '{val}' is not a database backend")
+        raise ArgumentTypeError(str(e)) from e
+    else:
+        if not isinstance(backend, DatabaseBackend):
+            raise ArgumentTypeError(f"Backend '{val}' is not a database backend")
     return val
 
 


### PR DESCRIPTION
Simple improvements:

1. Rely on the exception to create its own string.
2. Use the try/else syntax to clarify when the `isinstance` check is necessary.